### PR TITLE
fix: route from_dict() measurements through measure() for validation.

### DIFF
--- a/qomputing/circuit.py
+++ b/qomputing/circuit.py
@@ -249,7 +249,7 @@ class QuantumCircuit:
             )
         for pair in payload.get("measurements", []):
             q, c = int(pair[0]), int(pair[1])
-            circuit._measurements.append((q, c))
+            circuit.measure([q], [c])
         return circuit
 
     # Internal helpers -----------------------------------------------------


### PR DESCRIPTION
### Description:

`QuantumCircuit.from_dict()` appends measurements directly to the private `_measurements` list, bypassing all validation that the `measure()` method provides (qubit bounds, classical bit bounds, length matching). This allows malformed JSON circuit files to create invalid circuits that crash during simulation.

**Fix:** Route deserialized measurements through `measure()` instead of directly appending to `_measurements.`