### PR TITLE
fix(xeb): validate malformed samples add regression tests lazy-load package exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,5 @@ qomputing-sim = "qomputing.cli:main"
 [tool.setuptools.packages.find]
 where = ["."]
 
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/qomputing/__init__.py
+++ b/qomputing/__init__.py
@@ -1,10 +1,9 @@
 """Qomputing Simulator package."""
 
-from .backend import Backend, QomputingSimulator, Result
-from .circuit import Gate, QuantumCircuit
-from .engine import SimulationResult, StateVectorSimulator
-from .run import load_circuit, random_circuit, run, run_xeb
-from .xeb import LinearXEBResult, compute_linear_xeb_fidelity, run_linear_xeb_experiment
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "Gate",
@@ -25,3 +24,33 @@ __all__ = [
     "random_circuit",
 ]
 
+_EXPORT_MODULES = {
+    "Gate": ".circuit",
+    "QuantumCircuit": ".circuit",
+    "StateVectorSimulator": ".engine",
+    "SimulationResult": ".engine",
+    "LinearXEBResult": ".xeb",
+    "compute_linear_xeb_fidelity": ".xeb",
+    "run_linear_xeb_experiment": ".xeb",
+    "QomputingSimulator": ".backend",
+    "Backend": ".backend",
+    "Result": ".backend",
+    "load_circuit": ".run",
+    "run": ".run",
+    "run_xeb": ".run",
+    "random_circuit": ".run",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(module_name, __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/qomputing/xeb.py
+++ b/qomputing/xeb.py
@@ -30,16 +30,21 @@ def compute_linear_xeb_fidelity(
         raise ValueError("XEB fidelity requires at least one sample")
 
     num_qubits = len(samples[0])
-    dimension = 1 << num_qubits
+    if any(len(s) != num_qubits for s in samples):
+        raise ValueError("All samples must have the same bit-width")
+    if any(ch not in "01" for s in samples for ch in s):
+        raise ValueError("Samples must be binary strings")
 
     probs = list(ideal_probabilities)
+    dimension = 1 << num_qubits
     if len(probs) != dimension:
         raise ValueError("Ideal probability vector size does not match bitstring width")
 
-    prob_lookup = {format(index, f"0{num_qubits}b"): float(p) for index, p in enumerate(probs)}
-    average_p = sum(prob_lookup[bitstring] for bitstring in samples) / len(samples)
-    fidelity = dimension * average_p - 1.0
-    return fidelity
+    total = 0.0
+    for s in samples:
+        total += float(probs[int(s, 2)])
+    average_p = total / len(samples)
+    return dimension * average_p - 1.0
 
 
 def run_linear_xeb_experiment(

--- a/tests/test_xeb.py
+++ b/tests/test_xeb.py
@@ -1,0 +1,28 @@
+import pytest
+
+from qomputing.xeb import compute_linear_xeb_fidelity
+
+
+def test_compute_linear_xeb_fidelity_rejects_empty_samples() -> None:
+    with pytest.raises(ValueError, match="at least one sample"):
+        compute_linear_xeb_fidelity([1.0], [])
+
+
+def test_compute_linear_xeb_fidelity_rejects_mismatched_sample_width() -> None:
+    with pytest.raises(ValueError, match="same bit-width"):
+        compute_linear_xeb_fidelity([0.25, 0.25, 0.25, 0.25], ["00", "0"])
+
+
+def test_compute_linear_xeb_fidelity_rejects_non_binary_samples() -> None:
+    with pytest.raises(ValueError, match="binary strings"):
+        compute_linear_xeb_fidelity([0.25, 0.25, 0.25, 0.25], ["00", "2a"])
+
+
+def test_compute_linear_xeb_fidelity_rejects_probability_vector_size_mismatch() -> None:
+    with pytest.raises(ValueError, match="vector size"):
+        compute_linear_xeb_fidelity([0.5, 0.5], ["00", "01"])
+
+
+def test_compute_linear_xeb_fidelity_valid_input() -> None:
+    fidelity = compute_linear_xeb_fidelity([0.1, 0.2, 0.3, 0.4], ["00", "01", "10", "11"])
+    assert fidelity == pytest.approx(0.0)


### PR DESCRIPTION
- added test for xeb
- Add robust sample validation in linear XEB fidelity to raise clear ValueErrors instead of KeyError
- prevent python -m qomputing.xeb runtime warning by lazily exporting package symbols
- configure pytest to prioritize local package imports