### PR TITLE
Refactor: Add classical bit collision check, measure_all convenience method, and public measurement API

### DIFF
--- a/qomputing/engine/statevector.py
+++ b/qomputing/engine/statevector.py
@@ -36,9 +36,10 @@ class StateVectorSimulator:
         if result_shots:
             rng = np.random.default_rng(seed)
             samples = measurements.sample_measurements(probabilities, circuit.num_qubits, result_shots, rng)
-            if circuit.num_clbits and circuit._measurements:
+            # [Fix: Use public measurements property instead of private member access]
+            if circuit.num_clbits and circuit.measurements:
                 counts = measurements.samples_to_classical_counts(
-                    samples, circuit.num_qubits, circuit._measurements, circuit.num_clbits
+                    samples, circuit.num_qubits, list(circuit.measurements), circuit.num_clbits
                 )
             else:
                 counts = measurements.counts_from_samples(samples)


### PR DESCRIPTION
. Bug Fix: Classical Bit Collision Protection

Updated QuantumCircuit.measure to include a validation check that prevents multiple qubits from being measured into the same classical bit index.
This prevents silent data corruption/overwriting in the measurement result dictionary.
2. Feature: 
measure_all()
 Convenience Method

Added QuantumCircuit.measure_all(), which automatically maps all $N$ qubits to $N$ classical bits.
This significantly simplifies code for standard algorithms (like GHZ or Bell state preparation) where every qubit needs to be sampled.
3. Refactor: Public Measurement API & Encapsulation

Added a public 
measurements
 property to 
QuantumCircuit
 that returns an immutable tuple of the measurement map.
Updated the 
StateVectorSimulator
 engine to use this public property instead of accessing private internal state (
_measurements
), adhering better to encapsulation principles.
4. Documentation

Added descriptive inline comments to the source code to mark these improvements for future maintainers.